### PR TITLE
Update to work with GHES

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ This sample app showcases how webhooks can be used with a GitHub App's installat
 ## Setup
 
 1. Clone this repository.
-2. Create a `.env` file similar to `.env.example` and set actual values.
+2. Create a `.env` file similar to `.env.example` and set actual values. If you are using GitHub Enterprise Server, also include a `ENTERPRISE_HOSTNAME` variable and set the value to the name of your GitHub Enterprise Server instance.
 3. Install dependencies with `npm install`.
 4. Start the server with `npm run server`.
 5. Ensure your server is reachable from the internet.

--- a/app.js
+++ b/app.js
@@ -12,10 +12,22 @@ const appId = process.env.APP_ID;
 const privateKeyPath = process.env.PRIVATE_KEY_PATH;
 const privateKey = fs.readFileSync(privateKeyPath, "utf8");
 const secret = process.env.WEBHOOK_SECRET;
+const enterpriseHostname = process.env.ENTERPRISE_HOSTNAME;
 const messageForNewPRs = fs.readFileSync("./message.md", "utf8");
 
 // Create an authenticated Octokit client authenticated as a GitHub App
-const app = new App({ appId, privateKey, webhooks: { secret }});
+const app = new App({
+  appId: appId,
+  privateKey: privateKey,
+  webhooks: {
+    secret: secret
+  },
+  ...(enterpriseHostname && {
+    Octokit: Octokit.defaults({
+      baseUrl: `https://${enterpriseHostname}/api/v3`,
+    }),
+  }),
+})
 
 // Optional: Get & log the authenticated app's name
 const { data } = await app.octokit.request("/app");


### PR DESCRIPTION
Updates the code to work with GHES as well by relying on a 'ENTERPRISE_HOSTNAME' environment varible to set 'baseUrl' when creating a new Octokit App instance.