### PR TITLE
Add ownership.yaml for durable ownership of the project

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -8,12 +8,6 @@ ownership:
     exec_sponsor: scottdensmore
     product_manager: hpsin
     repo: https://github.com/github/github-app-js-sample
-    sev1:
-      issue: https://github.com/github/github-app-js-sample/issues
-      tta: '1 business day'
-    sev2:
-      issue: https://github.com/github/github-app-js-sample/issues
-      tta: '5 business days'
     sev3:
       issue: https://github.com/github/github-app-js-sample/issues
       slack: ce-apps


### PR DESCRIPTION
This adds the `ownership.yaml` file to ensure we have maintain proper service ownership before open sourcing the project.