### PR TITLE
fix fetch setup issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This sample app showcases how webhooks can be used with a GitHub App's installat
 
 ## Requirements
 
-- Node.js 12 or higher
+- Node.js 20 or higher
 - A GitHub App subscribed to **Pull Request** events and with the following permissions:
   - Pull requests: Read & write
   - Metadata: Read-only


### PR DESCRIPTION
When I run `npm run server`, I encountered the error below. I want to fix this by installing a fetch library and have the app to use it.

======
npm run server

> starter_github_app@0.0.1 server
> node app.js

/Users/msu/github-app-js-sample/node_modules/@octokit/request/dist-node/index.js:69
    throw new Error(
          ^

Error: fetch is not set. Please pass a fetch implementation as new Octokit({ request: { fetch }}). Learn more at https://github.com/octokit/octokit.js/#fetch-missing
    at fetchWrapper (/Users/msu/github-app-js-sample/node_modules/@octokit/request/dist-node/index.js:69:11)
    at request2 (/Users/msu/github-app-js-sample/node_modules/@octokit/request/dist-node/index.js:192:14)
    at hook (/Users/msu/github-app-js-sample/node_modules/@octokit/auth-app/dist-node/index.js:364:24)
    at async requestWithGraphqlErrorHandling (/Users/msu/github-app-js-sample/node_modules/@octokit/plugin-retry/dist-node/index.js:71:20)
    at async Job.doExecute (/Users/msu/github-app-js-sample/node_modules/bottleneck/light.js:405:18)

======

