### PR TITLE
feat: Add package info to PR comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,15 @@ const privateKeyPath = process.env.PRIVATE_KEY_PATH
 const privateKey = fs.readFileSync(privateKeyPath, 'utf8')
 const secret = process.env.WEBHOOK_SECRET
 const enterpriseHostname = process.env.ENTERPRISE_HOSTNAME
-const messageForNewPRs = fs.readFileSync('./message.md', 'utf8')
+const messageTemplate = fs.readFileSync('./message.md', 'utf8')
+const { name, version } = JSON.parse(fs.readFileSync('./package.json', 'utf8'))
+
+const GREETING_MESSAGE = `\`\`\`
+Package: ${name}
+Version: ${version}
+\`\`\`
+
+${messageTemplate}`
 
 // Create an authenticated Octokit client authenticated as a GitHub App
 const app = new App({
@@ -43,7 +51,7 @@ app.webhooks.on('pull_request.opened', async ({ octokit, payload }) => {
       owner: payload.repository.owner.login,
       repo: payload.repository.name,
       issue_number: payload.pull_request.number,
-      body: messageForNewPRs
+      body: GREETING_MESSAGE
     })
   } catch (error) {
     if (error.response) {

--- a/message.md
+++ b/message.md
@@ -1,5 +1,10 @@
+<details>
+<summary>PR guidelines</summary>
+
 👋 Hi there!
 
 Thanks for opening a new PR. Please, consider following this [guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) to make your PR easier to review.
 
 Also, check this new feature to [use markdown helpers](https://github.blog/changelog/2023-03-15-introducing-the-github-markdown-helpers-public-beta/) in your PR.
+
+</details>


### PR DESCRIPTION
I've modified the GitHub App to include package information from `package.json` in the comments it posts on new pull requests.

The package name and version are now displayed at the top of the comment, formatted in a style similar to the output of the `apt` package manager.

I've also wrapped the existing pull request guidelines in a collapsible `<details>` tag to improve the presentation.