### PR TITLE
Add maintainer information to ownership.yaml

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -7,6 +7,7 @@ ownership:
     team: github/ecosystem-apps
     exec_sponsor: d-sharanya
     product_manager: hpsin
+    maintainer: nebiyou-gebretatios
     repo: https://github.com/github/github-app-js-sample
     sev3:
       issue: https://github.com/github/github-app-js-sample/issues


### PR DESCRIPTION
Add nebiyou-gebretatios as maintainer. This is part of work to add the engineering manager of the owning team to all services.